### PR TITLE
Fix(#3): MediaLocationRepository 오류 수정

### DIFF
--- a/src/main/java/solitour_backend/solitour/media_location/repository/MediaLocationRepositoryImpl.java
+++ b/src/main/java/solitour_backend/solitour/media_location/repository/MediaLocationRepositoryImpl.java
@@ -19,10 +19,10 @@ public class MediaLocationRepositoryImpl implements MediaLocationRepositoryCusto
     }
 
     @Override
-    public List<MediaLocation> findLocationByTitle(List<String> placeName) {
+    public List<MediaLocation> findLocationByTitle(List<String> contentTitles) {
         return queryFactory
                 .selectFrom(QMediaLocation.mediaLocation)
-                .where(QMediaLocation.mediaLocation.placeName.in(placeName))
+                .where(QMediaLocation.mediaLocation.mediaName.in(contentTitles))
                 .fetch();
     }
 }


### PR DESCRIPTION
## 📝작업 내용

findLocationByTitle 메서드에서 mediaName을 사용해야 하는 부분에 placeName을 사용하는 오류를 수정하였습니다.

### 작업에 대한 스크린샷

![1](https://github.com/user-attachments/assets/38e1b4b9-4bfb-4d38-9763-410e547e1507)

위의 사진과 같이 findLocationByTitle 메서드는 media_name 배열을 parameter로 전달합니다.

![2](https://github.com/user-attachments/assets/76803640-893f-461a-9c21-0637fa98c9cc)

하지만 해당 메서드에서는 media_name이 아니라 place_name을 사용하고 있습니다.

따라서 다음과 같이 수정하였습니다.

```java
@Override
public List<MediaLocation> findLocationByTitle(List<String> contentTitles) {
    return queryFactory
            .selectFrom(QMediaLocation.mediaLocation)
            .where(QMediaLocation.mediaLocation.mediaName.in(contentTitles))
            .fetch();
}
```

## #️⃣연관된 이슈

close #3 