### PR TITLE
Fix(#8): 여행계획 id가 없어서 수정,삭제 안되는 문제 해결

### DIFF
--- a/src/main/java/solitour_backend/solitour/travel_plan/controller/TravelPlanController.java
+++ b/src/main/java/solitour_backend/solitour/travel_plan/controller/TravelPlanController.java
@@ -45,12 +45,13 @@ public class TravelPlanController {
         return ResponseEntity.ok(userPlan);
     }
 
-    @PutMapping("/user-plan/{userPlanId}")
+    @PutMapping("/user-plan/{planId}")
     public ResponseEntity<String> updateUserPlan(
-            @PathVariable Long userPlanId,
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long planId,
             @RequestBody UserPlanRequest userPlanRequest) {
 
-        travelPlanService.updateUserPlan(userPlanId, userPlanRequest);
+        travelPlanService.updateUserPlan(userId,planId, userPlanRequest);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/solitour_backend/solitour/travel_plan/controller/TravelPlanController.java
+++ b/src/main/java/solitour_backend/solitour/travel_plan/controller/TravelPlanController.java
@@ -54,9 +54,9 @@ public class TravelPlanController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/user-plan/{userPlanId}")
-    public ResponseEntity<String> deleteUserPlan(@PathVariable Long userPlanId) {
-        travelPlanService.deleteUserPlan(userPlanId);
+    @DeleteMapping("/user-plan/{planId}")
+    public ResponseEntity<String> deleteUserPlan(@AuthenticationPrincipal Long userId, @PathVariable Long planId) {
+        travelPlanService.deleteUserPlan(userId, planId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/solitour_backend/solitour/travel_plan/repository/UserPlanRepository.java
+++ b/src/main/java/solitour_backend/solitour/travel_plan/repository/UserPlanRepository.java
@@ -1,6 +1,7 @@
 package solitour_backend.solitour.travel_plan.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import solitour_backend.solitour.travel_plan.entity.UserPlan;
@@ -16,4 +17,11 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
 
     @Query("SELECT u FROM UserPlan u WHERE u.id = :userPlanId")
     UserPlan getUserPlan(Long userPlanId);
+
+    @Query("SELECT COUNT(u) > 0 FROM UserPlan u WHERE u.user.id = :userId AND u.plan.id = :planId")
+    boolean checkUserPlan(Long userId, Long planId);
+
+    @Modifying
+    @Query("DELETE FROM UserPlan WHERE user.id = :userId AND plan.id = :planId")
+    void deleteUserPlan(Long userId, Long planId);
 }

--- a/src/main/java/solitour_backend/solitour/travel_plan/repository/UserPlanRepository.java
+++ b/src/main/java/solitour_backend/solitour/travel_plan/repository/UserPlanRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 import solitour_backend.solitour.travel_plan.entity.UserPlan;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
     @Query("SELECT u FROM UserPlan u WHERE u.user.id = :userId")
@@ -24,4 +25,7 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
     @Modifying
     @Query("DELETE FROM UserPlan WHERE user.id = :userId AND plan.id = :planId")
     void deleteUserPlan(Long userId, Long planId);
+
+    @Query("SELECT u FROM UserPlan u WHERE u.user.id = :userId AND u.plan.id = :planId")
+    Optional<UserPlan> findUserPlan(Long userId, Long planId);
 }

--- a/src/main/java/solitour_backend/solitour/travel_plan/service/TravelPlanService.java
+++ b/src/main/java/solitour_backend/solitour/travel_plan/service/TravelPlanService.java
@@ -221,10 +221,10 @@ public class TravelPlanService {
     }
 
     @Transactional
-    public void deleteUserPlan(Long userPlanId) {
-        if (!userPlanRepository.existsById(userPlanId)) {
-            throw new IllegalArgumentException("UserPlan not found with ID: " + userPlanId);
+    public void deleteUserPlan(Long userId, Long planId) {
+        if (!userPlanRepository.checkUserPlan(userId, planId)) {
+            throw new IllegalArgumentException("해당하는 UserPlan이 존재하지 않습니다.");
         }
-        userPlanRepository.deleteById(userPlanId);
+        userPlanRepository.deleteUserPlan(userId,planId);
     }
 }

--- a/src/main/java/solitour_backend/solitour/travel_plan/service/TravelPlanService.java
+++ b/src/main/java/solitour_backend/solitour/travel_plan/service/TravelPlanService.java
@@ -186,9 +186,9 @@ public class TravelPlanService {
     }
 
     @Transactional
-    public void updateUserPlan(Long userPlanId, UserPlanRequest userPlanRequest) {
-        UserPlan userPlan = userPlanRepository.findById(userPlanId)
-                .orElseThrow(() -> new IllegalArgumentException("UserPlan not found with ID: " + userPlanId));
+    public void updateUserPlan(Long userId, Long planId, UserPlanRequest userPlanRequest) {
+        UserPlan userPlan = userPlanRepository.findUserPlan(userId, planId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 UserPlan이 존재하지 않습니다."));
 
         Plan plan = userPlan.getPlan();
         plan.setTitle(userPlanRequest.plan().title());


### PR DESCRIPTION
## 📝작업 내용

여행계획 리스트 조회시에 여행계획 id가 없어서 수정,삭제가 불가능한 문제를 해결
여행 id, 유저 id를 조합해서 여행계획 id를 특정하여 수정, 삭제가 가능하도록 변경

## #️⃣연관된 이슈

#8 
