### PR TITLE
Fix(#14): CORS 에러 및 쿠키 SameSite 정책 문제 해결

### DIFF
--- a/src/main/java/solitour_backend/solitour/auth/config/AuthConfiguration.java
+++ b/src/main/java/solitour_backend/solitour/auth/config/AuthConfiguration.java
@@ -42,6 +42,7 @@ public class AuthConfiguration implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         final String[] ALLOWED_URLS = {
                 "http://localhost:3000",
+                "https://www.solitourist.com",
                 "https://solitour.ssssksss.xyz",
                 "https://solitour-admin.ssssksss.xyz"
         };

--- a/src/main/java/solitour_backend/solitour/auth/controller/OauthController.java
+++ b/src/main/java/solitour_backend/solitour/auth/controller/OauthController.java
@@ -117,7 +117,7 @@ public class OauthController {
     }
 
     private String setCookieHeader(Cookie cookie) {
-        return String.format("%s=%s; Path=%s; Max-Age=%d;Secure; HttpOnly; SameSite=Lax",
+        return String.format("%s=%s; Path=%s; Max-Age=%d; Secure; HttpOnly; SameSite=None",
                 cookie.getName(), cookie.getValue(), cookie.getPath(), cookie.getMaxAge());
     }
 


### PR DESCRIPTION
## 📝작업 내용

- `SameSite=Lax`를 `SameSite=None`으로 변경
- CORS 에러 해결을 위해 ALLOWED_URLS에 `https://www.solitourist.com`를 추가

## #️⃣연관된 이슈

close #14